### PR TITLE
chore: bump Go toolchain from 1.20 to 1.26.3

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.20
+      - name: Set up Go 1.26.3
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.26.3"
 
       - name: Install dependencies
         run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/raniellyferreira/rotate-files
 
-go 1.20
+go 1.26.3
 
 require (
 	cloud.google.com/go/storage v1.43.0


### PR DESCRIPTION
## Summary

- Bumps Go from **1.20** (EOL since Feb/2024) to **1.26.3** in both `go.mod` and the CI workflow.
- Unblocks the 7 open Dependabot PRs (#198, #227, #230, #231, #232, #233, #234), all of which currently fail CI because their new dependency versions require Go >= 1.21.
- Supersedes the stale draft #191 (which was also a Go + deps refresh, but coupled with broader changes).

## Why now

- Go 1.20 reached end-of-life in February 2024 — no more security patches.
- The CI workflow pinning Go 1.20 has been the single root cause of every red Dependabot PR for the past 10+ months.
- No release has been cut since v1.3.1 (Oct/2024); this PR is step 1 of a coordinated catch-up culminating in v1.4.0.

## Changes

| File | Change |
|---|---|
| `go.mod` | `go 1.20` → `go 1.26.3` |
| `.github/workflows/unit-tests.yml` | `go-version: "1.20"` → `"1.26.3"` |

No source code changes. No public API changes.

## Test plan

- [x] `go build ./...` — green locally with Go 1.26.3
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass (`internal/utils`, `pkg/files`, `pkg/rotate`)
- [x] `make test-unit` (CI command) — passes
- [x] `make coverage` (CI command) — passes; reported coverage unchanged
- [ ] GitHub Actions `Go Unit Test` workflow — green on this PR

## Notes for consumers

Library users compiling with Go < 1.26.3 will need to upgrade their toolchain. This will land in **v1.4.0** (minor bump per conservative SemVer — toolchain floor change is not API-breaking, but it is a behavioral floor change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)